### PR TITLE
Guidelines Update

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -1,0 +1,7 @@
+#Governance Framework
+
+- Traefik is Open Source
+- Traefik provides a welcoming and respectful environment to everyone, in all situations
+- Governance is transparent: Decisions are documented, and collaboration should be done in public
+
+See the [Code of Conduct](https://github.com/traefik/traefik/blob/master/CODE_OF_CONDUCT.md)

--- a/governance.md
+++ b/governance.md
@@ -1,4 +1,4 @@
-#Governance Framework
+# Governance Framework
 
 - Traefik is Open Source
 - Traefik provides a welcoming and respectful environment to everyone, in all situations

--- a/issue_triage.md
+++ b/issue_triage.md
@@ -12,7 +12,7 @@ Triaging involves categorizing issues and PRs based on factors such as priority/
 
 - Each project is responsible for handling their own issues or pull requests
 
-Triaging occurs in regularly scheduled daily meetings and may occur asynchronously depending on the severity of the issue or PR
+Triaging occurs in regularly scheduled meetings and may occur asynchronously depending on the severity of the issue or PR
 
 ## Why Is Triaging Beneficial?
 

--- a/issue_triage.md
+++ b/issue_triage.md
@@ -7,7 +7,7 @@ Projects are welcome to use this guidance as a starting point and customize to a
 
 ## What Is Triaging?
 
-Issue triage is a process by which a project intakes and reviews new GitHub issues and requests, and organizes them to be actioned—usually by its own members.
+Issue triage is a process by which a project intakes and reviews new GitHub issues and requests, and organizes them to be actioned — usually by its own members.
 Triaging involves categorizing issues and PRs based on factors such as priority/severity, ownership of the issue, and the issue kind (bug, feature, etc.)
 
 - Each project is responsible for handling their own issues or pull requests
@@ -45,10 +45,10 @@ In almost all cases, these bots take action based on certain activities being pe
 
 ## Review Newly Created Open Issues
 
-Project issues, and labels are listed for each project here:
+Project issues and labels are listed for each project here:
 
-- [Traefik](https://github.com/containous/traefik/issues)
-- [Labels](https://github.com/containous/traefik/labels)
+- [Traefik issues](https://github.com/containous/traefik/issues)
+- [Labels](https://github.com/containous/traefik/labels) and their [description](./labels.md)
 
 New, untriaged issues are assigned the label `status/0-needs-triage` automatically.
 During the issue triage meeting, project leads could identify at least one team member to serve as the individual responsible for applying labels and assigning ownership for incoming issues that require any action.
@@ -105,7 +105,7 @@ Once triaged, issues should be assigned one of the following `kind` labels:
 
 - `kind/bug/possible` or `kind/bug/confirmed`
 - `kind/enhancement`
-- `kind/proposal`
+- `kind/proposal` see [Proposals](./proposals.md)
 - `kind/question`
 
 ## Define Priority
@@ -143,6 +143,10 @@ Based on the labels applied to the issue, it may be closed for the following rea
 - `contributor/waiting-for-feedback` or `contributor/need-more-information` are automatically closed after 60 days of no activity
 - `kind/question` are automatically closed after 8 days with no activity
 - closed issues have `status/5-frozen-due-to-age` applied automatically after 30 days of no activity
+
+## Abuse reports
+
+According to our [Code of Conduct](https://github.com/traefik/traefik/blob/master/CODE_OF_CONDUCT.md), [abuse reports](https://github.com/traefik/traefik/reported_content) should be handled during the triage process as well.
 
 ## Footnotes
 

--- a/labels.md
+++ b/labels.md
@@ -1,0 +1,92 @@
+# Labels
+
+A maintainer that looks at an issue/PR must define its `kind/*`, `area/*`, and `status/*`.
+
+## Status - Workflow
+
+The `status/*` labels represent the desired state in the workflow.
+
+* `status/0-needs-triage`: all the new issues and PRs have this status. _[bot only]_
+* `status/1-needs-design-review`: needs a design review. **(only for PR)**
+* `status/2-needs-review`: needs a code/documentation review. **(only for PR)**
+* `status/3-needs-merge`: ready to merge. **(only for PR)**
+* `status/4-merge-in-progress`: merge is in progress. _[bot only]_
+
+## Contributor
+
+* `contributor/need-more-information`: we need more information from the contributor in order to analyze a problem.
+* `contributor/waiting-for-feedback`: we need the contributor to give us feedback.
+* `contributor/waiting-for-corrections`: we need the contributor to take actions in order to move forward with a PR. **(only for PR)** _[bot, humans]_
+* `contributor/needs-resolve-conflicts`: use it only when there is some conflicts (and an automatic rebase is not possible). **(only for PR)** _[bot, humans]_
+
+## Kind
+
+* `kind/enhancement`: a new or improved feature.
+* `kind/question`: a question. **(only for issue)**
+* `kind/proposal`: a proposal that needs to be discussed.
+    * _Proposal issues_ are design proposals
+    * _Proposal PRs_ are technical prototypes that need to be refined with multiple contributors.
+
+* `kind/bug/possible`: a possible bug that needs analysis before it is confirmed or fixed. **(only for issues)**
+* `kind/bug/confirmed`: a confirmed bug (reproducible). **(only for issues)**
+* `kind/bug/fix`: a bug fix. **(only for PR)**
+
+## Resolution
+
+* `resolution/duplicate`: a duplicate issue/PR.
+* `resolution/declined`: declined (Rule #1 of open-source: no is temporary, yes is forever).
+* `WIP`: Work In Progress. **(only for PR)**
+
+## Platform
+
+* `platform/windows`: Windows related.
+
+## Area
+
+* `area/acme`: ACME related.
+* `area/api`: Traefik API related.
+* `area/authentication`: Authentication related.
+* `area/cluster`: Traefik clustering related.
+* `area/documentation`: Documentation related.
+* `area/infrastructure`: CI or Traefik building scripts related.
+* `area/healthcheck`: Health-check related.
+* `area/logs`: Logs related.
+* `area/middleware`: Middleware related.
+* `area/middleware/metrics`: Metrics related. (Prometheus, StatsD, ...)
+* `area/middleware/tracing`: Tracing related. (Jaeger, Zipkin, ...)
+* `area/oxy`: Oxy related.
+* `area/provider`: related to all providers.
+* `area/provider/boltdb`: Boltd DB related.
+* `area/provider/consul`: Consul related.
+* `area/provider/docker`: Docker and Swarm related.
+* `area/provider/ecs`: ECS related.
+* `area/provider/etcd`: Etcd related.
+* `area/provider/eureka`: Eureka related.
+* `area/provider/file`: file provider related.
+* `area/provider/k8s`: Kubernetes related.
+* `area/provider/kv`: KV related.
+* `area/provider/marathon`: Marathon related.
+* `area/provider/mesos`: Mesos related.
+* `area/provider/servicefabric`: Azure service fabric related.
+* `area/provider/zk`: Zoo Keeper related.
+* `area/rules`: Rules related.
+* `area/server`: Server related.
+* `area/sticky-session`: Sticky session related.
+* `area/tls`: TLS related.
+* `area/websocket`: WebSocket related.
+* `area/webui`: Web UI related.
+
+## Issues Priority
+
+* `priority/P0`: needs hot fix.
+* `priority/P1`: need to be fixed in next release.
+* `priority/P2`: need to be fixed in the future.
+* `priority/P3`: maybe.
+
+## PR Size
+
+Automatically set by a bot.
+
+* `size/S`: small PR.
+* `size/M`: medium PR.
+* `size/L`: Large PR.

--- a/proposals.md
+++ b/proposals.md
@@ -1,0 +1,20 @@
+# Proposals & Enhancements
+
+Issues that contain new feature ideas or important enhancements are labelled with `kind/proposal`
+
+As written in the [PR Guidelines](./pr_guidelines.md), contributors should always write such proposals prior to submitting a PR so they can discuss with maintainers about not only the design and code standards for the PR itself, but also the feature. 
+Contributors can still accompany PRs with a proposal to provide a proof of concept or prototype.
+
+## Proposals and Workflow
+
+During the triage process, proposals should be assigned a time frame to allow community members to express their opinion, and maintainers to refine the need and fully understand the scope of the feature being discussed.
+
+Once the time frame is over, maintainers will document their decision to either: 
+- accept the proposal
+- reject and close the proposal
+- extend the time needed to refine it
+
+## Re-Opening a proposal
+
+Closed proposals can be re-opened whenever there is notable activity from the community. 
+This happens during the triage process.

--- a/proposals.md
+++ b/proposals.md
@@ -7,7 +7,7 @@ Contributors can still accompany PRs with a proposal to provide a proof of conce
 
 ## Proposals and Workflow
 
-During the triage process, proposals should be assigned a time frame to allow community members to express their opinion, and maintainers to refine the need and fully understand the scope of the feature being discussed.
+During the triage process, proposals should ideally be assigned a time frame to allow community members to express their opinion, and maintainers to refine the need and fully understand the scope of the feature being discussed.
 
 Once the time frame is over, maintainers will document their decision to either: 
 - accept the proposal

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,9 @@ This repository is an experimental way of exposing and improving how the maintai
 
 This document should serve as a general guideline on how contributions from the community are handled and prioritized.
 
+* [Governance](./governance.md)
 * [Issue Triage](./issue_triage.md)
+* [Proposals](./proposals.md)
 * [Pull Request Guidelines](./pr_guidelines.md)
 * [Review Guidelines](./review_guidelines.md)
 * [Help Wanted](./help_wanted.md)


### PR DESCRIPTION
## Context
Traefik is an open-source project, and we (Traefik Labs) want to ensure the project is community-driven. We want the community (users, contributors, maintainers) to have full latitude to improve traefik and steer it in the right direction.

## Description
This PR updates the existing guidelines about contribution and philosophy, making sure it contains up-to-date information.

The General Philosophy of the changes are: 
- Traefik must provide a welcoming and respectful environment to everyone, users, contributors, and maintainers alike, in all situations
- A contribution (PR or Issue) should always be prioritized
- Maintainers have to document every decision on issues and PRs
- It is possible and easy to become an external maintainer
- Introduce time frames on proposals and contributions, making sure there is no stalling issue or PR
- List inactive maintainers in a dedicated section

Traefik Labs supports and promotes the project but fully opens the governance to the community.
